### PR TITLE
Provide easier way to change the amount of log generation rate

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,15 @@ Execute these steps to run your load test:
         behavior: replace
         env: api-keys.txt
 
+      patches:
+      - target:
+        kind: Deployment
+        name: load-generator*
+        patch: |-
+        - op: replace
+          path: /spec/replicas
+          value: 1
+      
      configMapGenerator:
      - name: loadgen-telemetry-configmap
        namespace: scalyr-loadgen
@@ -113,23 +122,32 @@ Execute these steps to run your load test:
       number of pods per account, leaving the default value of 5MB/s of logs generated per pod.
       
       To increase the number of pods per account, you need to modify the number of replicas listed
-      in the `k8s/base/peraccount/load-generator.yaml` manifest file.  The default is 1.
+      in the `patches` section of your `kustomization.yaml` file.
       
       Here is an example where we adjust the replicas to 5:
       
       ```
-      apiVersion: apps/v1
-      kind: Deployment
-      metadata:
-        name: load-generator
-        namespace: scalyr-loadgen
-      spec:
-        replicas: 5
+      ...
+
+      patches:
+      - target:
+        kind: Deployment
+        name: load-generator*
+        patch: |-
+        - op: replace
+          path: /spec/replicas
+          value: 5
       ...
       ```
       
       With 5 replicas, we would generate 25MB/s per load account, giving us a total of 50MB/s of load
       across the two accounts.
+
+      You may also change the amount of logs generated per pod by modifying the `LOGS_MBS_PER_POD`
+      entry in the `load-generator-configmap` in our `kustomization.yaml` file.  The value may be
+      any number (including fractional) less than 5 and represents the number megabytes of logs
+      will be generated per second per pod.  Note, if you do reduce this value, you will be
+      required to run more pods and expend more CPU to generate the target rate.
   
   7.  Start the load test
   

--- a/example/kustomization.yaml
+++ b/example/kustomization.yaml
@@ -26,6 +26,17 @@ secretGenerator:
   envs:
   - api-keys.txt
 
+# Modifies the number of load generator pods to run per account.
+# Change `value` below to increase the number of pods.
+patches:
+- target:
+    kind: Deployment
+    name: load-generator*
+  patch: |-
+    - op: replace
+      path: /spec/replicas
+      value: 1
+
 configMapGenerator:
 - name: loadgen-telemetry-configmap
   namespace: scalyr-loadgen
@@ -34,12 +45,15 @@ configMapGenerator:
     - SCALYR_K8S_CLUSTER_NAME=loadgen-telemetry-cluster
 # Uncomment the next line to use the eu.scalyr.com instead of www.scalyr.com
 #    - SCALYR_SERVER=https://app.eu.scalyr.com
+
 - name: load-generator-configmap
   namespace: scalyr-loadgen
   behavior: replace
   literals:
     - SCALYR_K8S_CLUSTER_NAME=loadgen-cluster
-    - LOG_MBS_PER_POD=5
+    # Modify this value to change the number of log bytes generated
+    # (in MB/s) per pod.  This value may be fractional.
+    - LOG_MBS_PER_POD=5.0
 # Uncomment the next line to use the eu.scalyr.com instead of www.scalyr.com
 #    - SCALYR_SERVER=https://app.eu.scalyr.com
 


### PR DESCRIPTION
We can leverage some newer features in `kustomize` to allow modifying both
of the key load generation parameters (the number of pods run per account and
the number of log bytes generate per pod) from within the `kustomization.yaml`
created by the user.

Normally, this would be a no-brainer in my mind, but this is a last minute change.
The only real risk is that it does rely on a somewhat recent feature, so the customer
must be sure to use `kustomize` 3.2 or higher.

So, even if we do not use it for the upcoming load test, I'll probably incorporate it
in the main branch.