### PR TITLE
PLAT-1557 adding nodeAffinity and podAntiAffinity

### DIFF
--- a/k8s/base/accounts/load-generator-01/load-generator-01.yaml
+++ b/k8s/base/accounts/load-generator-01/load-generator-01.yaml
@@ -5,6 +5,21 @@ metadata:
 spec:
   template:
     spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: purpose
+                    operator: In
+                    values:
+                      - general
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchLabels:
+                  app: load-generator
+              topologyKey: kubernetes.io/hostname
       containers:
       - name: scalyr-agent
         env:

--- a/k8s/base/accounts/load-generator-02/load-generator-02.yaml
+++ b/k8s/base/accounts/load-generator-02/load-generator-02.yaml
@@ -5,6 +5,21 @@ metadata:
 spec:
   template:
     spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: purpose
+                    operator: In
+                    values:
+                      - general
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchLabels:
+                  app: load-generator
+              topologyKey: kubernetes.io/hostname
       containers:
       - name: scalyr-agent
         env:

--- a/k8s/base/accounts/load-generator-03/load-generator-03.yaml
+++ b/k8s/base/accounts/load-generator-03/load-generator-03.yaml
@@ -5,6 +5,21 @@ metadata:
 spec:
   template:
     spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: purpose
+                    operator: In
+                    values:
+                      - general
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchLabels:
+                  app: load-generator
+              topologyKey: kubernetes.io/hostname
       containers:
       - name: scalyr-agent
         env:

--- a/k8s/base/accounts/load-generator-04/load-generator-04.yaml
+++ b/k8s/base/accounts/load-generator-04/load-generator-04.yaml
@@ -5,6 +5,21 @@ metadata:
 spec:
   template:
     spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: purpose
+                    operator: In
+                    values:
+                      - general
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchLabels:
+                  app: load-generator
+              topologyKey: kubernetes.io/hostname
       containers:
       - name: scalyr-agent
         env:

--- a/k8s/base/accounts/load-generator-05/load-generator-05.yaml
+++ b/k8s/base/accounts/load-generator-05/load-generator-05.yaml
@@ -5,6 +5,21 @@ metadata:
 spec:
   template:
     spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: purpose
+                    operator: In
+                    values:
+                      - general
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchLabels:
+                  app: load-generator
+              topologyKey: kubernetes.io/hostname
       containers:
       - name: scalyr-agent
         env:

--- a/k8s/base/accounts/load-generator-06/load-generator-06.yaml
+++ b/k8s/base/accounts/load-generator-06/load-generator-06.yaml
@@ -5,6 +5,21 @@ metadata:
 spec:
   template:
     spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: purpose
+                    operator: In
+                    values:
+                      - general
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchLabels:
+                  app: load-generator
+              topologyKey: kubernetes.io/hostname
       containers:
       - name: scalyr-agent
         env:

--- a/k8s/base/accounts/load-generator-07/load-generator-07.yaml
+++ b/k8s/base/accounts/load-generator-07/load-generator-07.yaml
@@ -5,6 +5,21 @@ metadata:
 spec:
   template:
     spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: purpose
+                    operator: In
+                    values:
+                      - general
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchLabels:
+                  app: load-generator
+              topologyKey: kubernetes.io/hostname
       containers:
       - name: scalyr-agent
         env:

--- a/k8s/base/accounts/load-generator-08/load-generator-08.yaml
+++ b/k8s/base/accounts/load-generator-08/load-generator-08.yaml
@@ -5,6 +5,21 @@ metadata:
 spec:
   template:
     spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: purpose
+                    operator: In
+                    values:
+                      - general
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchLabels:
+                  app: load-generator
+              topologyKey: kubernetes.io/hostname
       containers:
       - name: scalyr-agent
         env:

--- a/k8s/base/accounts/load-generator-09/load-generator-09.yaml
+++ b/k8s/base/accounts/load-generator-09/load-generator-09.yaml
@@ -5,6 +5,21 @@ metadata:
 spec:
   template:
     spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: purpose
+                    operator: In
+                    values:
+                      - general
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchLabels:
+                  app: load-generator
+              topologyKey: kubernetes.io/hostname
       containers:
       - name: scalyr-agent
         env:

--- a/k8s/base/accounts/load-generator-10/load-generator-10.yaml
+++ b/k8s/base/accounts/load-generator-10/load-generator-10.yaml
@@ -5,6 +5,21 @@ metadata:
 spec:
   template:
     spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: purpose
+                    operator: In
+                    values:
+                      - general
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchLabels:
+                  app: load-generator
+              topologyKey: kubernetes.io/hostname
       containers:
       - name: scalyr-agent
         env:

--- a/k8s/base/cluster/loadgen-telemetry-daemonset.yaml
+++ b/k8s/base/cluster/loadgen-telemetry-daemonset.yaml
@@ -12,7 +12,7 @@ spec:
       labels:
         app: loadgen-telemetry
     spec:
-      serviceAccountName: scalyr-service-account
+      serviceAccountName: scalyr-loadgen-service-account
       containers:
       - name: scalyr-agent
         image:  scalyr/scalyr-k8s-agent:2.1.29

--- a/k8s/base/cluster/scalyr-service-account.yaml
+++ b/k8s/base/cluster/scalyr-service-account.yaml
@@ -1,13 +1,14 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: scalyr-service-account
+  name: scalyr-loadgen-service-account
   namespace: scalyr-loadgen
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: scalyr-clusterrole
+  name: scalyr-loadgen-clusterrole
+  namespace: scalyr-loadgen
 rules:
 - apiGroups: [""]
   resources: ["namespaces","pods","replicationcontrollers"]
@@ -35,12 +36,12 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: scalyr-clusterrole-binding
+  name: scalyr-loadgen-clusterrole-binding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: scalyr-clusterrole
+  name: scalyr-loadgen-clusterrole
 subjects:
   - kind: ServiceAccount
-    name: scalyr-service-account
+    name: scalyr-loadgen-service-account
     namespace: scalyr-loadgen

--- a/k8s/base/peraccount/load-generator.yaml
+++ b/k8s/base/peraccount/load-generator.yaml
@@ -19,7 +19,7 @@ spec:
         log.config.scalyr.com/agent-telemetry.attributes.parser: "scalyrAgentLog"
         log.config.scalyr.com/flog-telemetry.attributes.parser: "flogTelemetryParser"
     spec:
-      serviceAccountName: scalyr-service-account
+      serviceAccountName: scalyr-loadgen-service-account
 
       containers:
       - name: flog-load


### PR DESCRIPTION
What problem does this solve:
- pods are jammed into 1 node and wasn't able to generate as much traffic.
- loadgen pods taking too much resources and interfere other pods.

What does this change do:
spread pods across nodes to get more compute and bandwidth.

What are the side-effects:
node group auto-scaling max might have to adjust to accommodate the number of pods being spin up.